### PR TITLE
perf: improve `clear` efficiency

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -184,8 +184,15 @@ export const createLRU = <Key, Value>(options: CacheOptions<Key, Value>) => {
 
     /** Clears all key-value pairs from the cache. */
     clear(): undefined {
-      for (const index of keyMap.values())
-        onEviction?.(keyList[index]!, valList[index]!);
+      const iterator = keyMap.values();
+
+      if (typeof onEviction === 'function')
+        for (
+          let result = iterator.next();
+          !result.done;
+          result = iterator.next()
+        )
+          onEviction(keyList[result.value]!, valList[result.value]!);
 
       keyMap.clear();
       keyList.fill(undefined);

--- a/src/index.ts
+++ b/src/index.ts
@@ -184,15 +184,16 @@ export const createLRU = <Key, Value>(options: CacheOptions<Key, Value>) => {
 
     /** Clears all key-value pairs from the cache. */
     clear(): undefined {
-      const iterator = keyMap.values();
+      if (typeof onEviction === 'function') {
+        const iterator = keyMap.values();
 
-      if (typeof onEviction === 'function')
         for (
           let result = iterator.next();
           !result.done;
           result = iterator.next()
         )
           onEviction(keyList[result.value]!, valList[result.value]!);
+      }
 
       keyMap.clear();
       keyList.fill(undefined);


### PR DESCRIPTION
Only loop through the evictions when the `onEvict` method is used.