### PR TITLE
security(.npmrc): ignore npm scripts

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true


### PR DESCRIPTION
After the recent supply chain attacks that use install scripts, this simple update prevents the automatic installation of npm scripts for maintainers and contributors.

> [!NOTE]
> 
> - There is no security fault, this is just a precaution.
> - The end user isn't affected by this change 🙋🏻‍♂️

---

**Related:**

- https://github.com/sidorares/node-mysql2/pull/3805